### PR TITLE
Odds caching

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1728,6 +1728,11 @@
         "wrap-ansi": "^5.1.0"
       }
     },
+    "clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
+    },
     "cls-bluebird": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cls-bluebird/-/cls-bluebird-2.1.0.tgz",
@@ -2411,8 +2416,7 @@
     "filesize": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/filesize/-/filesize-3.6.1.tgz",
-      "integrity": "sha512-7KjR1vv6qnicaPMi1iiTcI85CyYwRO/PSFCu6SvqL8jN2Wjt/NIYQTFtFs7fSDCYOstUkEWIQGFUg5YZQfjlcg==",
-      "dev": true
+      "integrity": "sha512-7KjR1vv6qnicaPMi1iiTcI85CyYwRO/PSFCu6SvqL8jN2Wjt/NIYQTFtFs7fSDCYOstUkEWIQGFUg5YZQfjlcg=="
     },
     "fill-range": {
       "version": "4.0.0",
@@ -2570,7 +2574,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2588,11 +2593,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2605,15 +2612,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2716,7 +2726,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2726,6 +2737,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2738,17 +2750,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2765,6 +2780,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2837,7 +2853,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2847,6 +2864,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2922,7 +2940,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2952,6 +2971,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2969,6 +2989,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3007,11 +3028,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },
@@ -3904,6 +3927,14 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
+    },
+    "node-cache": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-5.0.1.tgz",
+      "integrity": "sha512-W+a/8TIkGThCdyDeKzDWqf3qUSHDc+Zo/a55AIfGWB5y7l2mMTtBbRya3nzyzB6FJap0vWIaa/4mnFVm6HGfew==",
+      "requires": {
+        "clone": "2.x"
+      }
     },
     "node-libs-browser": {
       "version": "2.2.1",
@@ -5606,7 +5637,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/volleyball/-/volleyball-1.5.1.tgz",
       "integrity": "sha512-JUY9rRJRKTlhcDkbeoVNyqduCvZlI/GFQJx6G4loWRUD6KRvBepO5E0mVB6tgvjiSwjhs7DBru8unpNUK7FZgg==",
-      "dev": true,
       "requires": {
         "chalk": "^2.4.0",
         "debug": "^3.1.0",
@@ -5617,7 +5647,6 @@
           "version": "3.2.6",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
           "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "dev": true,
           "requires": {
             "ms": "^2.1.1"
           }
@@ -5625,8 +5654,7 @@
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "dotenv-webpack": "^1.7.0",
     "express": "^4.17.1",
     "https": "^1.0.0",
+    "node-cache": "^5.0.1",
     "pg": "^6.4.2",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",

--- a/server/routes/odds.js
+++ b/server/routes/odds.js
@@ -3,8 +3,9 @@ const router = express.Router();
 const chalk = require('chalk')
 const { Game } = require('../db/models')
 const jsonOdds = require('./jsonOdds')
+const TTL = process.env.CACHE_TTL || 60
 const nodecache = require('node-cache')
-const cache = new nodecache({stdTTL: 60})
+const cache = new nodecache({stdTTL: TTL})
 
 const upsert = (values, condition) => {
   return Game.findOne({

--- a/server/routes/odds.js
+++ b/server/routes/odds.js
@@ -3,6 +3,8 @@ const router = express.Router();
 const chalk = require('chalk')
 const { Game } = require('../db/models')
 const jsonOdds = require('./jsonOdds')
+const nodecache = require('node-cache')
+const cache = new nodecache({stdTTL: 60})
 
 const upsert = (values, condition) => {
   return Game.findOne({
@@ -35,10 +37,19 @@ const chooseId = obj => {
 
 router.get('/:sport', (req, res, next) => {
   const sportString = req.params.sport
-  jsonOdds.get(`https://jsonodds.com/api/odds/${sportString}?oddType=Game`)
-  .then(res => res.data)
-  .then(details => res.json(details))
-  .catch(console.error)
+  let apiURL = `https://jsonodds.com/api/odds/${sportString}?oddType=Game`
+  let apiData = cache.get(apiURL)
+  if(apiData){
+    res.json(apiData)
+  } else {
+    jsonOdds.get(apiURL)
+    .then(res => res.data)
+    .then(function (details) {
+      res.json(details)
+      cache.set(apiURL, details)
+    })
+    .catch(console.error)
+  }
 })
 
 router.get('/:sport/games', (req, res, next) => {

--- a/server/routes/results.js
+++ b/server/routes/results.js
@@ -2,13 +2,24 @@ const express = require('express');
 const router = express.Router();
 const chalk = require('chalk')
 const jsonOdds = require('./jsonOdds')
+const nodecache = require('node-cache')
+const cache = new nodecache({stdTTL: 60})
 
 router.get('/:sport', (req, res, next) => {
   const sportString = req.params.sport
-  jsonOdds.get(`https://jsonodds.com/api/results/${sportString}?oddType=game`)
-  .then(res => res.data)
-  .then(details => res.json(details))
-  .catch(console.error)
+  let apiURL = `https://jsonodds.com/api/odds/${sportString}?oddType=Game`
+  let apiData = cache.get(apiURL)
+  if(apiData){
+    res.json(apiData)
+  } else {
+    jsonOdds.get(apiURL)
+    .then(res => res.data)
+    .then(function (details) {
+      res.json(details)
+      cache.set(apiURL, details)
+    })
+    .catch(console.error)
+  }
 })
 
 module.exports = router

--- a/server/routes/results.js
+++ b/server/routes/results.js
@@ -2,8 +2,9 @@ const express = require('express');
 const router = express.Router();
 const chalk = require('chalk')
 const jsonOdds = require('./jsonOdds')
+const TTL = process.env.CACHE_TTL || 60
 const nodecache = require('node-cache')
-const cache = new nodecache({stdTTL: 60})
+const cache = new nodecache({stdTTL: TTL})
 
 router.get('/:sport', (req, res, next) => {
   const sportString = req.params.sport


### PR DESCRIPTION
Implemented caching on the API call within the Odds and Results APIs.
- Added a new package node-cache
- Added a new environment variable CACHE_TTL to set the length of the TTL for the cache
- If the environment variable is not set the default TTL will be 60 seconds, I would recommend starting at a TTL of 30 seconds and seeing how it works.